### PR TITLE
Fixes for pjsip transport-tls

### DIFF
--- a/asterisk/rootfs/etc/asterisk/pjsip.conf
+++ b/asterisk/rootfs/etc/asterisk/pjsip.conf
@@ -12,7 +12,9 @@ bind=0.0.0.0
 type=transport
 protocol=tls
 bind=0.0.0.0:5061
-cert_file=/etc/asterisk/keys/asterisk.pem
+method=tlsv1_2
+cert_file=/etc/asterisk/keys/fullchain.pem
+priv_key_file=/etc/asterisk/keys/privkey.pem
 
 [transport-wss]
 type=transport


### PR DESCRIPTION
- pjsip needs a separate privkey. mixing cert and privkey in one file does not work.
- accepting TLS < 1.3, see workaround in https://issues.asterisk.org/jira/browse/ASTERISK-29017

With these changes I am able to use pjsip_custom.conf for normal hardware phones (yealink was tested) or linphone with TLS 1.2 or higher. Default in asterisk seems to be 1.3 because of the bug mentioned above.

There is no change on the wss  transport, so no effect to sipjs card.