### PR TITLE
Increase maximum possible number of SDP formats

### DIFF
--- a/asterisk/Dockerfile
+++ b/asterisk/Dockerfile
@@ -113,7 +113,8 @@ RUN cp --verbose ../asterisk-opus*/codecs/* codecs; \
     patch -p1 < ../asterisk-opus*/asterisk.patch
 
 # patch: increase the number of format entries in SDPs to 128
-RUN sed -i 's/^\(#define\s\+PJMEDIA_MAX_SDP_FMT\s\+\).*/\1128/' ./third-party/pjproject/patches/config_site.h
+RUN sed -i 's/^\(#define\s\+PJMEDIA_MAX_SDP_FMT\s\+\).*/\1128/' ./third-party/pjproject/patches/config_site.h; \
+    cat ./third-party/pjproject/patches/config_site.h
 
 RUN \
     # Recreate the configure script as we patched it above for the new formats \

--- a/asterisk/Dockerfile
+++ b/asterisk/Dockerfile
@@ -112,6 +112,9 @@ RUN cp --verbose ../asterisk-opus*/codecs/* codecs; \
     cp --verbose ../asterisk-opus*/formats/* formats; \
     patch -p1 < ../asterisk-opus*/asterisk.patch
 
+# patch: increase the number of format entries in SDPs to 128
+RUN sed -i 's/^\(#define\s\+PJMEDIA_MAX_SDP_FMT\s\+\).*/\1128/' ./third-party/pjproject/patches/config_site.h
+
 RUN \
     # Recreate the configure script as we patched it above for the new formats \
     ./bootstrap.sh; \

--- a/asterisk/Dockerfile
+++ b/asterisk/Dockerfile
@@ -112,9 +112,11 @@ RUN cp --verbose ../asterisk-opus*/codecs/* codecs; \
     cp --verbose ../asterisk-opus*/formats/* formats; \
     patch -p1 < ../asterisk-opus*/asterisk.patch
 
+#copy patches specific for this addon
+COPY patches /usr/src/asterisk-patches
+WORKDIR /usr/src/asterisk
 # patch: increase the number of format entries in SDPs to 128
-RUN sed -i 's/^\(#define\s\+PJMEDIA_MAX_SDP_FMT\s\+\).*/\1128/' ./third-party/pjproject/patches/config_site.h; \
-    cat ./third-party/pjproject/patches/config_site.h
+RUN patch -p0 --verbose < /usr/src/asterisk-patches/0000-increase_max_number_of_sdp_format_entries.patch;
 
 RUN \
     # Recreate the configure script as we patched it above for the new formats \

--- a/asterisk/patches/0000-increase_max_number_of_sdp_format_entries.patch
+++ b/asterisk/patches/0000-increase_max_number_of_sdp_format_entries.patch
@@ -1,0 +1,11 @@
+--- third-party/pjproject/patches/config_site.h.orig	2022-03-31 18:28:38.648833646 +0200
++++ third-party/pjproject/patches/config_site.h	2022-03-31 18:29:02.488871683 +0200
+@@ -75,7 +75,7 @@
+ #define PJ_ICE_MAX_CHECKS (PJ_ICE_MAX_CAND * PJ_ICE_MAX_CAND)
+ 
+ /* Increase limits to allow more formats */
+-#define	PJMEDIA_MAX_SDP_FMT   64
++#define	PJMEDIA_MAX_SDP_FMT   128
+ #define	PJMEDIA_MAX_SDP_BANDW   4
+ #define	PJMEDIA_MAX_SDP_ATTR   (PJMEDIA_MAX_SDP_FMT*2 + 4)
+ #define	PJMEDIA_MAX_SDP_MEDIA   16


### PR DESCRIPTION
When using Chromium-based browsers, it might happen that the generated SDPs by the browsers WebRTC engine generates a lot of entries and attributes. For example when a lot of codecs incl. audio AND video are offered.

This will lead to the following error messages in asterisk:
```
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] WARNING[667]: pjproject: <?>: 	                 sdp.c .Error adding media attribute, attribute is ignored: Too many objects of the specified type (PJ_ETOOMANY)
[Mar 23 09:10:54] ERROR[667]: pjproject: <?>: 	             sip_inv.c .Error parsing/validating SDP body: Missing SDP rtpmap for dynamic payload type (PJMEDIA_SDP_EMISSINGRTPMAP)
```

Inspired by this posting: https://stackoverflow.com/questions/39275328/asterisk-13-10-pjsip-webrtc-rx-buffer-overflow-pjsip-erxoverflow
