### PR TITLE
Media

### DIFF
--- a/asterisk/CHANGELOG.md
+++ b/asterisk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## 2.1.4
+
+- Increase maximum possible number of SDP formats (#140) (by @nanosonde)
+
 ## 2.1.3
 
 - Fix TLS transport

--- a/asterisk/CHANGELOG.md
+++ b/asterisk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## 2.1.3
+
+- Fix TLS transport
+- Set NAT settings
+- Include default STUN server
+
 ## 2.1.2
 
 - Fix timezone

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -1,5 +1,5 @@
 name: Asterisk
-version: 2.1.3
+version: 2.1.4
 slug: asterisk
 description: PBX server for SIP devices like doorbells and phones
 url: https://github.com/TECH7Fox/asterisk-hass-addons

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -13,6 +13,7 @@ arch:
 homeassistant_api: true
 map:
   - config:rw
+  - media:rw
   - ssl
 options:
   video_support: true

--- a/asterisk/rootfs/etc/cont-init.d/asterisk.sh
+++ b/asterisk/rootfs/etc/cont-init.d/asterisk.sh
@@ -94,3 +94,25 @@ bashio::var.json \
 
 rsync -a -v --ignore-existing /etc/asterisk/. /config/asterisk/ || bashio::exit.nok 'Failed to make sample configs.' # Doesn't overwrite
 cp -a -f /config/asterisk/. /etc/asterisk/ || bashio::exit.nok 'Failed to get config from /config/asterisk.' # Does overwrite
+
+# Copy sounds to /media/asterisk
+if ! bashio::fs.directory_exists '/media/asterisk'; then
+    mkdir -p /media/asterisk ||
+        bashio::exit.nok 'Failed to create initial asterisk media folder'
+fi
+
+if ! bashio::fs.directory_exists '/media/asterisk/moh'; then
+    mkdir -p /media/asterisk/moh ||
+        bashio::exit.nok 'Failed to create initial asterisk media/moh folder'
+fi
+
+if ! bashio::fs.directory_exists '/media/asterisk/sounds'; then
+    mkdir -p /media/asterisk/sounds ||
+        bashio::exit.nok 'Failed to create initial asterisk media/sounds folder'
+fi
+
+rsync -a -v --ignore-existing /var/lib/asterisk/moh/. /media/asterisk/moh/ || bashio::exit.nok 'Failed to make sample moh.'          # Doesn't overwrite
+rsync -a -v --ignore-existing /var/lib/asterisk/sounds/. /media/asterisk/sounds/ || bashio::exit.nok 'Failed to make sample sounds.' # Doesn't overwrite
+
+cp -a -f /media/asterisk/moh. /var/lib/asterisk/moh/ || bashio::exit.nok 'Failed to get moh from /media/asterisk/moh.'               # Does overwrite
+cp -a -f /media/asterisk/sounds. /var/lib/asterisk/sounds/ || bashio::exit.nok 'Failed to get config from /media/asterisk/sounds.'   # Does overwrite

--- a/asterisk/rootfs/etc/cont-init.d/asterisk.sh
+++ b/asterisk/rootfs/etc/cont-init.d/asterisk.sh
@@ -114,5 +114,4 @@ fi
 rsync -a -v --ignore-existing /var/lib/asterisk/moh/. /media/asterisk/moh/ || bashio::exit.nok 'Failed to make sample moh.'          # Doesn't overwrite
 rsync -a -v --ignore-existing /var/lib/asterisk/sounds/. /media/asterisk/sounds/ || bashio::exit.nok 'Failed to make sample sounds.' # Doesn't overwrite
 
-cp -a -f /media/asterisk/moh. /var/lib/asterisk/moh/ || bashio::exit.nok 'Failed to get moh from /media/asterisk/moh.'               # Does overwrite
-cp -a -f /media/asterisk/sounds. /var/lib/asterisk/sounds/ || bashio::exit.nok 'Failed to get config from /media/asterisk/sounds.'   # Does overwrite
+cp -a -f /media/asterisk/. /var/lib/asterisk/ || bashio::exit.nok 'Failed to get sounds from /media/asterisk/.' # Does overwrite


### PR DESCRIPTION
Created a start on #117.

Now it acts the same like the config. Restores the ones missing, and then overwrites from `/media/asterisk`.

Maybe it should only restore files if `/media/asterisk` is missing, so people don't have to use the same file names and can remove files?

Only thing to do is to stop downloading in dockerfile and only download if the `/media/asterisk` doesn't exist, right?

What do you think @felipecrs @nanosonde ?