### PR TITLE
Add back chan_sip on alternate 52xx ports

### DIFF
--- a/asterisk/Dockerfile
+++ b/asterisk/Dockerfile
@@ -167,7 +167,8 @@ RUN \
         --enable chan_bridge_media \
         --enable chan_iax2 \
         --enable chan_pjsip \
-        --enable chan_rtp; \
+        --enable chan_rtp \
+        --enable chan_sip ; \
     # enable good things \
     menuselect/menuselect --enable BETTER_BACKTRACES menuselect.makeopts; \
     # applications \

--- a/asterisk/rootfs/etc/asterisk/extensions.conf
+++ b/asterisk/rootfs/etc/asterisk/extensions.conf
@@ -9,6 +9,9 @@ exten => 444,1,Park(,s)
 exten => 555,1,ParkedCall(default,701)
 ;
 exten => _X!,1,Dial(${PJSIP_DIAL_CONTACTS(${EXTEN})})
+;
+;extension for dialing chan_sip devices.
+;exten => _X!,1,Dial(SIP/${EXTEN})
 
 [parkedcallstimeout]
 exten => s,1,Hangup()

--- a/asterisk/rootfs/etc/asterisk/extensions.conf
+++ b/asterisk/rootfs/etc/asterisk/extensions.conf
@@ -15,3 +15,4 @@ exten => _X!,1,Dial(${PJSIP_DIAL_CONTACTS(${EXTEN})})
 
 [parkedcallstimeout]
 exten => s,1,Hangup()
+;

--- a/asterisk/rootfs/etc/asterisk/sip.conf
+++ b/asterisk/rootfs/etc/asterisk/sip.conf
@@ -1,0 +1,24 @@
+[general]
+udpbindaddr=0.0.0.0:5260
+bindaddr=0.0.0.0:5260
+protocol=udp
+
+; TLS
+tlsenable=yes
+tlsbindaddr=0.0.0.0:5261
+tlscertfile=/etc/asterisk/keys/asterisk.pem
+tlscipher=ALL
+tlsclientmethod=ALL
+
+; HINTS
+limitonpeers=yes
+notifyringing=yes
+notifyhold=yes
+notifycid=yes
+callcounter=yes
+
+; AUTO GENERATED SIP.JS EXTENSIONS
+#include sip_default.conf
+
+; CUSTOM EXTENSIONS
+#include sip_custom.conf

--- a/asterisk/rootfs/etc/cont-init.d/asterisk.sh
+++ b/asterisk/rootfs/etc/cont-init.d/asterisk.sh
@@ -91,6 +91,15 @@ bashio::var.json \
     tempio \
         -template /usr/share/tempio/pjsip_default.conf.gtpl \
         -out /config/asterisk/pjsip_default.conf
+        
+ bashio::var.json \
+    auto_add "^${auto_add}" \
+    auto_add_secret "${auto_add_secret}" \
+    video_support "^${video_support}" \
+    persons "^${persons}" |
+    tempio \
+        -template /usr/share/tempio/sip_default.conf.gtpl \
+        -out /config/asterisk/sip_default.conf    
 
 rsync -a -v --ignore-existing /etc/asterisk/. /config/asterisk/ || bashio::exit.nok 'Failed to make sample configs.' # Doesn't overwrite
 cp -a -f /config/asterisk/. /etc/asterisk/ || bashio::exit.nok 'Failed to get config from /config/asterisk.' # Does overwrite

--- a/asterisk/rootfs/usr/share/tempio/sip_default.conf.gtpl
+++ b/asterisk/rootfs/usr/share/tempio/sip_default.conf.gtpl
@@ -1,0 +1,37 @@
+; DON'T MODIFY THIS FILE, IT GET'S OVERWRITTEN!
+; IF YOU REALLY WANT TO CHANGE sipjs-phone OR my-codecs, YOU CAN ADD THAT IN sip_custom.conf OR EVEN sip.conf
+
+[sipjs-phone](!)
+type=friend
+host=dynamic ; Allows any host to register
+encryption=yes ; Tell Asterisk to use encryption for this peer
+avpf=yes ; Tell Asterisk to use AVPF for this peer
+icesupport=yes ; Tell Asterisk to use ICE for this peer
+context=default ; Tell Asterisk which context to use when this peer is dialing
+directmedia=no ; Asterisk will relay media for this peer
+transport=wss,udp,tls ; Asterisk will allow this peer to register on UDP or WebSockets
+force_avp=yes ; Force Asterisk to use avp. Introduced in Asterisk 11.11
+dtlsenable=yes ; Tell Asterisk to enable DTLS for this peer
+dtlsverify=fingerprint ; Tell Asterisk to verify DTLS fingerprint
+dtlscertfile=/etc/asterisk/keys/asterisk.pem ; Tell Asterisk where your DTLS cert file is
+dtlssetup=actpass ; Tell Asterisk to use actpass SDP parameter when setting up DTLS
+rtcp_mux=yes ; Tell Asterisk to do RTCP mux
+dtmfmode=rfc2833
+qualify=no
+sendrpid=pai
+videosupport={{ .video_support }}
+busylevel=1
+
+[my-codecs](!)
+allow=!all,ulaw,alaw,speex,gsm,g726,g723,h263,h263p,h264,vp8
+
+{{ if .auto_add }}
+{{ $secret := .auto_add_secret }}
+{{  range $index, $person := .persons }}
+{{   $extension := add 100 $index }}
+[{{ $extension }}](sipjs-phone,my-codecs)
+username={{ $extension }}
+secret={{ $secret }}
+callerid="{{ $person }}" <{{ $extension }}>
+{{   end }}
+{{ end }}


### PR DESCRIPTION
To get the compatibility with Dahua doorbells I reactivated chan_sip on an alternate upd/tcp port 52xx