### PR TITLE
Enable res_resolver_unbound

### DIFF
--- a/asterisk/Dockerfile
+++ b/asterisk/Dockerfile
@@ -91,6 +91,7 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
         libsqlite3-dev \
         libsrtp2-dev \
         libssl-dev \
+        libunbound-dev \
         libvorbis-dev \
         libxml2-dev \
         libxslt1-dev \
@@ -153,6 +154,7 @@ RUN \
         --with-opus \
         --with-opusfile \
         --with-resample \
+        --with-unbound \
         --without-asound \
         --without-bluetooth \
         --without-dahdi \


### PR DESCRIPTION
Added libraries and corresponding configuration option to enable the 'resolver_unbound' module.