### PR TITLE
Use `friendly_name` instead of `id` as caller id

### DIFF
--- a/asterisk/rootfs/etc/cont-init.d/asterisk.sh
+++ b/asterisk/rootfs/etc/cont-init.d/asterisk.sh
@@ -145,7 +145,7 @@ if bashio::var.true "${auto_add}"; then
             -H "Authorization: Bearer ${ha_token}" \
             -H "Content-Type: application/json" \
             "${ha_url}/api/states" |
-            jq -c '[.[] | select(.entity_id | contains("person.")).attributes.id]'
+            jq -c '[.[] | select(.entity_id | contains("person.")).attributes.friendly_name]'
     )
 else
     # Define an empty array, so the subsequent template won't complain


### PR DESCRIPTION
Following up on #321.

Please note that I was able to test the curl command in isolation to ensure I'm getting the list of names correctly, but I don't currently have a setup that I can do e2e tests with.