### PR TITLE
Fix `/config/asterisk/custom` files being overwritten on restarts

### DIFF
--- a/asterisk/CHANGELOG.md
+++ b/asterisk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Changelog
 
+## 4.2.1
+
+### Bug Fixes
+
+- Use `friendly_name` instead of `id` as caller id (by @OnFreund at #322)
+- Fix `/config/asterisk/custom` files being overwritten on container restart (by @felipecrs at #323, fixes #309)
+  - PS: this bug did not affect people running the add-on with Home Assistant Supervisor, only for people running the add-on as a standalone docker container.
+
 ## 4.2.0
 
 ### New Features

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -1,5 +1,5 @@
 name: Asterisk
-version: 4.2.0
+version: 4.2.1
 slug: asterisk
 description: PBX server for SIP devices like doorbells and phones
 url: https://github.com/TECH7Fox/asterisk-hass-addons

--- a/asterisk/rootfs/etc/cont-init.d/asterisk.sh
+++ b/asterisk/rootfs/etc/cont-init.d/asterisk.sh
@@ -103,18 +103,23 @@ if bashio::config.is_empty 'ami_password'; then
     bashio::exit.nok "'ami_password' must be set"
 fi
 
+# deleting the target before writing to it ensures we don't write to a
+# symlinked file, like when the container is restarted
+rm -f "${etc_asterisk}/manager.conf"
 bashio::var.json \
     password "$(bashio::config 'ami_password')" |
     tempio \
         -template "${tempio_dir}/manager.conf.gtpl" \
         -out "${etc_asterisk}/manager.conf"
 
+rm -f "${etc_asterisk}/logger.conf"
 bashio::var.json \
     log_level "$(bashio::config 'log_level')" |
     tempio \
         -template "${tempio_dir}/logger.conf.gtpl" \
         -out "${etc_asterisk}/logger.conf"
 
+rm -f "${etc_asterisk}/http.conf"
 bashio::var.json \
     certfile "${target_certfile}" \
     keyfile "${target_keyfile}" |
@@ -152,6 +157,7 @@ else
     persons=[]
 fi
 
+rm -f "${etc_asterisk}/pjsip_default.conf"
 bashio::var.json \
     auto_add "^${auto_add}" \
     auto_add_secret "${auto_add_secret}" \
@@ -161,6 +167,7 @@ bashio::var.json \
         -template "${tempio_dir}/pjsip_default.conf.gtpl" \
         -out "${etc_asterisk}/pjsip_default.conf"
 
+rm -f "${etc_asterisk}/sip_default.conf"
 bashio::var.json \
     auto_add "^${auto_add}" \
     auto_add_secret "${auto_add_secret}" \
@@ -170,6 +177,7 @@ bashio::var.json \
         -template "${tempio_dir}/sip_default.conf.gtpl" \
         -out "${etc_asterisk}/sip_default.conf"
 
+rm -f "${etc_asterisk}/asterisk_mbox.ini"
 bashio::var.json \
     port "$(bashio::config 'mailbox_port')" \
     password "$(bashio::config 'mailbox_password')" \


### PR DESCRIPTION
Thanks to @OnFreund (https://github.com/TECH7Fox/asterisk-hass-addons/issues/309#issuecomment-2068141220)

Closes #309
