### PR TITLE
Prefer Opus over other codecs

### DIFF
--- a/asterisk/rootfs/usr/share/tempio/pjsip_default.conf.gtpl
+++ b/asterisk/rootfs/usr/share/tempio/pjsip_default.conf.gtpl
@@ -44,7 +44,7 @@ rewrite_contact=yes
 direct_media=no
 context=default
 disallow=all
-allow=ulaw,alaw,speex,gsm,g726,g723,g722,opus
+allow=opus,ulaw,alaw,speex,gsm,g726,g723,g722
 {{ if .video_support -}}
 allow=h264,vp8,vp9
 {{- end }}


### PR DESCRIPTION
Opus is a superior codec to the other. Since most devices support ulaw and alaw, listing Opus after them means it will never be picked. This PR lists it first so it will be picked when available.