### PR TITLE
Enable HAOS Ingress

### DIFF
--- a/asterisk/CHANGELOG.md
+++ b/asterisk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Changelog
 
+## 5.2.0
+
+- Enable HAOS Ingress
+
 ## 5.1.0
 
 ### Breaking Changes

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -1,5 +1,5 @@
 name: Asterisk
-version: 5.1.0
+version: 5.2.0-b5
 breaking_versions:
   - 5.1.0
   - 5.0.0
@@ -55,3 +55,5 @@ host_network: true
 init: false
 uart: true # chan-dongle requirement
 stdin: true
+ingress: true
+ingress_port: 8088

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -1,5 +1,5 @@
 name: Asterisk
-version: 5.2.0-b5
+version: 5.2.0
 breaking_versions:
   - 5.1.0
   - 5.0.0

--- a/asterisk/rootfs/etc/cont-init.d/register-ingress-entry.sh
+++ b/asterisk/rootfs/etc/cont-init.d/register-ingress-entry.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Register ingress_url in HA
+# ==============================================================================
+
+# shellcheck shell=bash
+
+function api_call {
+  curl -sS -H "Authorization: Bearer $SUPERVISOR_TOKEN" -H "content-type: application/json" "$@"
+}
+
+if [[ -n "${SUPERVISOR_TOKEN:-}" ]]; then
+    INGRESS_ENTRY=$(api_call -X GET http://supervisor/addons/self/info | jq -r .data.ingress_entry)
+    bashio::log.info ingress_entry: $INGRESS_ENTRY
+    api_call -X POST http://supervisor/core/api/states/text.asterisk_addon_ingress_entry -d '{"state": "'${INGRESS_ENTRY}'"}'
+fi

--- a/asterisk/rootfs/usr/share/tempio/http.conf.gtpl
+++ b/asterisk/rootfs/usr/share/tempio/http.conf.gtpl
@@ -9,3 +9,5 @@ tlsenable=yes
 tlsbindaddr=[::]:8089
 tlscertfile={{ .certfile }}
 tlsprivatekey={{ .keyfile }}
+enablestatic=yes
+redirect=/ static/index.html

--- a/asterisk/rootfs/var/lib/asterisk/static-http/index.html
+++ b/asterisk/rootfs/var/lib/asterisk/static-http/index.html
@@ -1,0 +1,4 @@
+<html>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
This change exposes Asterisk builtin http server via HAOS ingress proxy (including websocket endpoint).
This will allow much simpler setup for `sip-hass-card` - it will be able to connect to Asterisk using existing HomeAssistant domain / SSL certificate (there is separate [PR](https://github.com/TECH7Fox/sip-hass-card/pull/131) for `sip-hass-card` )