### PR TITLE
Add AMI permit configuration option

### DIFF
--- a/asterisk/CHANGELOG.md
+++ b/asterisk/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 # Changelog
 
+## 6.3.0
+
+### New Features
+
+- Add `ami_permit` option to configure Asterisk Manager Interface allowed networks.
+
 ## 6.2.0
 
 ### New Features

--- a/asterisk/DOCS.md
+++ b/asterisk/DOCS.md
@@ -42,6 +42,25 @@ We expose some configuration options to simplify the setup of the Asterisk serve
 
 Set's the password for the Asterisk Manager Interface, to connect to the [Asterisk integration](https://github.com/TECH7Fox/Asterisk-integration).
 
+### Option: `ami_permit`
+
+The networks or hosts that are allowed to connect to the Asterisk Manager Interface. Each value is rendered as a `permit` line in `manager.conf`.
+
+The default allows local add-on access:
+
+```yaml
+ami_permit:
+  - 127.0.0.1/255.255.255.0
+```
+
+If Home Assistant or another trusted client connects from a non-loopback address, add that address with a host mask:
+
+```yaml
+ami_permit:
+  - 127.0.0.1/255.255.255.0
+  - 192.168.1.10/255.255.255.255
+```
+
 ### Option: `auto_add`
 
 Creates a extension for every [person](https://www.home-assistant.io/integrations/person/) registered in Home Assistant. They will have their number and username auto-generated starting from 100, with the `callerid` set to the person's name.

--- a/asterisk/config.yaml
+++ b/asterisk/config.yaml
@@ -20,6 +20,8 @@ map:
   - homeassistant_config:rw
 options:
   ami_password: null
+  ami_permit:
+    - 127.0.0.1/255.255.255.0
   auto_add: true
   auto_add_secret: ""
   video_support: false
@@ -36,6 +38,8 @@ options:
   log_level: info
 schema:
   ami_password: password
+  ami_permit:
+    - str
   auto_add: bool
   auto_add_secret: password
   video_support: bool

--- a/asterisk/rootfs/etc/asterisk-addon/default_config.json
+++ b/asterisk/rootfs/etc/asterisk-addon/default_config.json
@@ -1,5 +1,8 @@
 {
   "ami_password": null,
+  "ami_permit": [
+    "127.0.0.1/255.255.255.0"
+  ],
   "video_support": false,
   "auto_add": false,
   "auto_add_secret": "",

--- a/asterisk/rootfs/etc/cont-init.d/asterisk.sh
+++ b/asterisk/rootfs/etc/cont-init.d/asterisk.sh
@@ -108,11 +108,18 @@ if bashio::config.is_empty 'ami_password'; then
     bashio::exit.nok "'ami_password' must be set"
 fi
 
+readarray -t ami_permit < <(set +e && bashio::config 'ami_permit')
+ami_permit_lines=""
+for permit in "${ami_permit[@]}"; do
+    ami_permit_lines+="permit = ${permit}"$'\n'
+done
+
 # deleting the target before writing to it ensures we don't write to a
 # symlinked file, like when the container is restarted
 rm -f "${etc_asterisk}/manager.conf"
 bashio::var.json \
-    password "$(bashio::config 'ami_password')" |
+    password "$(bashio::config 'ami_password')" \
+    permit "${ami_permit_lines}" |
     tempio \
         -template "${tempio_dir}/manager.conf.gtpl" \
         -out "${etc_asterisk}/manager.conf"

--- a/asterisk/rootfs/usr/share/tempio/manager.conf.gtpl
+++ b/asterisk/rootfs/usr/share/tempio/manager.conf.gtpl
@@ -10,7 +10,7 @@ displayconnects = yes
 [admin]
 secret = {{ .password }}
 deny = 0.0.0.0/0.0.0.0
-permit = 127.0.0.1/255.255.255.0
+{{ .permit -}}
 read = system,call,log,verbose,command,agent,user,config,command,dtmf,reporting,cdr,dialplan,originate,message
 write = system,call,log,verbose,command,agent,user,config,command,dtmf,reporting,cdr,dialplan,originate,message
 writetimeout = 5000

--- a/asterisk/translations/en.yaml
+++ b/asterisk/translations/en.yaml
@@ -3,6 +3,12 @@ configuration:
     name: AMI Password
     description: >-
       The password that will be used for the `admin` user in AMI.
+  ami_permit:
+    name: AMI Permitted Networks
+    description: >-
+      The networks or hosts that are allowed to connect to the Asterisk Manager
+      Interface. Values are rendered as `permit` lines in `manager.conf`, for
+      example `127.0.0.1/255.255.255.0` or `192.168.1.10/255.255.255.255`.
   video_support:
     name: Video Support
     description: >-

--- a/asterisk/translations/pt-BR.yaml
+++ b/asterisk/translations/pt-BR.yaml
@@ -3,6 +3,13 @@ configuration:
     name: Senha AMI
     description: >-
       A senha que será usada para o usuário `admin` na AMI.
+  ami_permit:
+    name: Redes permitidas AMI
+    description: >-
+      As redes ou hosts que têm permissão para se conectar à Interface de
+      Gerenciamento do Asterisk. Os valores são renderizados como linhas
+      `permit` no `manager.conf`, por exemplo `127.0.0.1/255.255.255.0` ou
+      `192.168.1.10/255.255.255.255`.
   video_support:
     name: Suporte de vídeo
     description: >-


### PR DESCRIPTION
## Summary

- Add an `ami_permit` add-on option for Asterisk Manager Interface allowed networks.
- Render configured values as repeated `permit = ...` lines in generated `manager.conf`.
- Document the option and add EN/PT-BR translations.

Closes #452

## Validation

- Parsed `asterisk/config.yaml` and translation YAML files with PyYAML.
- Parsed `asterisk/rootfs/etc/asterisk-addon/default_config.json`.
- Ran `bash -n` on `asterisk/rootfs/etc/cont-init.d/asterisk.sh`.
- Ran `git diff --check`.

